### PR TITLE
fix: checkout bug

### DIFF
--- a/server-actions/stripe/account.ts
+++ b/server-actions/stripe/account.ts
@@ -12,12 +12,14 @@ export async function hasConnectedStripeAccount(
   useProvidedStoreId?: boolean
 ) {
   if (useProvidedStoreId && !providedStoreId) return;
-  const loggedInStoreId = Number(await getStoreId());
-  if (isNaN(loggedInStoreId)) return;
 
   try {
     const storeId =
-      useProvidedStoreId && providedStoreId ? providedStoreId : loggedInStoreId;
+      useProvidedStoreId && providedStoreId
+        ? providedStoreId
+        : Number(await getStoreId());
+
+    if (isNaN(storeId)) return;
 
     const payment = await db
       .select()


### PR DESCRIPTION
Further fix to #41 ensuring accounts that don't have a stripe account connected can still checkout with other sellers that do