### PR TITLE
bump to canary to fix revalidation bug

### DIFF
--- a/components/storefront/product-form.tsx
+++ b/components/storefront/product-form.tsx
@@ -9,6 +9,7 @@ import { toast } from "../ui/use-toast";
 import { ToastAction } from "../ui/toast";
 import { routes } from "@/lib/routes";
 import { cn, handleInputQuantity } from "@/lib/utils";
+import Link from "next/link";
 
 export const ProductForm = (props: {
   availableInventory: string | null;
@@ -58,9 +59,9 @@ export const ProductForm = (props: {
               title: "Added to cart",
               description: `${quantity}x ${props.productName} has been added to your cart.`,
               action: (
-                <a href={routes.cart}>
+                <Link href={routes.cart}>
                   <ToastAction altText="View cart">View</ToastAction>
-                </a>
+                </Link>
               ),
             });
           }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint-config-next": "13.3.0",
         "lucide-react": "^0.162.0",
         "mysql2": "^3.2.3",
-        "next": "^13.4.2",
+        "next": "^13.4.5-canary.8",
         "postcss": "8.4.22",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -3258,9 +3258,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.2.tgz",
-      "integrity": "sha512-Wqvo7lDeS0KGwtwg9TT9wKQ8raelmUxt+TQKWvG/xKfcmDXNOtCuaszcfCF8JzlBG1q0VhpI6CKaRMbVPMDWgw=="
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5-canary.8.tgz",
+      "integrity": "sha512-45Vzn4eiKMEUraPLUFBXNvy+jW2DLGMF4HrehpqmwRzLqaKOaOamO5g0Ca135efyNUl7yE2PjwVkZfsH4cKWzQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.3.0",
@@ -3291,9 +3291,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.2.tgz",
-      "integrity": "sha512-6BBlqGu3ewgJflv9iLCwO1v1hqlecaIH2AotpKfVUEzUxuuDNJQZ2a4KLb4MBl8T9/vca1YuWhSqtbF6ZuUJJw==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5-canary.8.tgz",
+      "integrity": "sha512-MkoyJzuK5OKWR8/M8jqjKyADkCzaCIXhvMzhQoj2ITCzIf5bl73DpC0F4RUg3C42xket7f80WcN5VHg76VU3IA==",
       "cpu": [
         "arm64"
       ],
@@ -3306,9 +3306,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.2.tgz",
-      "integrity": "sha512-iZuYr7ZvGLPjPmfhhMl0ISm+z8EiyLBC1bLyFwGBxkWmPXqdJ60mzuTaDSr5WezDwv0fz32HB7JHmRC6JVHSZg==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5-canary.8.tgz",
+      "integrity": "sha512-FIUdZgjmgWB+pTfJWG8CjXGjg64ZHnzd/mjn9ox9Gx0Hb8CXursL7XpiQcbhl8IeCRLqwV4/f5QQ0F0FVkqSCQ==",
       "cpu": [
         "x64"
       ],
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.2.tgz",
-      "integrity": "sha512-2xVabFtIge6BJTcJrW8YuUnYTuQjh4jEuRuS2mscyNVOj6zUZkom3CQg+egKOoS+zh2rrro66ffSKIS+ztFJTg==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5-canary.8.tgz",
+      "integrity": "sha512-EVV90FrSvTaqr2azdWWeAY+HUj7ok+nAc+py0QwBnFyjoK9QTAth+AwWGkY09ekHAiJVna/YucKDZFE9EV4EEg==",
       "cpu": [
         "arm64"
       ],
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.2.tgz",
-      "integrity": "sha512-wKRCQ27xCUJx5d6IivfjYGq8oVngqIhlhSAJntgXLt7Uo9sRT/3EppMHqUZRfyuNBTbykEre1s5166z+pvRB5A==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5-canary.8.tgz",
+      "integrity": "sha512-hqYwqrSVeS292St4fLHsZ15jOR53Uml7OSnfDtAYGzCIowAsIss4YJqyHtsIY7q+oSEwMS4tCWDNNECZPO6EPQ==",
       "cpu": [
         "arm64"
       ],
@@ -3351,9 +3351,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.2.tgz",
-      "integrity": "sha512-NpCa+UVhhuNeaFVUP1Bftm0uqtvLWq2JTm7+Ta48+2Uqj2mNXrDIvyn1DY/ZEfmW/1yvGBRaUAv9zkMkMRixQA==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5-canary.8.tgz",
+      "integrity": "sha512-7XlhTzV8AS+3PM1ijlgdYShzdxXZDoHgfuQsDr1vIBe16Y198eCc9SfKbrjKVe3PdqRaJbolPMCWcQViIWAYAA==",
       "cpu": [
         "x64"
       ],
@@ -3366,9 +3366,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.2.tgz",
-      "integrity": "sha512-ZWVC72x0lW4aj44e3khvBrj2oSYj1bD0jESmyah3zG/3DplEy/FOtYkMzbMjHTdDSheso7zH8GIlW6CDQnKhmQ==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5-canary.8.tgz",
+      "integrity": "sha512-a9K46D7pI3nNIA8ZbN+7XPWyAF2n1xLLbn4vIa46edn+M0Qdq0/qnF7uAvdRXWaQiBRAvIyRiOOznNPzIBXhkw==",
       "cpu": [
         "x64"
       ],
@@ -3381,9 +3381,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.2.tgz",
-      "integrity": "sha512-pLT+OWYpzJig5K4VKhLttlIfBcVZfr2+Xbjra0Tjs83NQSkFS+y7xx+YhCwvpEmXYLIvaggj2ONPyjbiigOvHQ==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5-canary.8.tgz",
+      "integrity": "sha512-bhOrlja/IfarpyEMg//ig6mn02kshW1M/Hl7dxrzsCukbdYPkELaR+fCZcxaKhwuSDp1QsQdL2JHokU4FIIWEw==",
       "cpu": [
         "arm64"
       ],
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.2.tgz",
-      "integrity": "sha512-dhpiksQCyGca4WY0fJyzK3FxMDFoqMb0Cn+uDB+9GYjpU2K5//UGPQlCwiK4JHxuhg8oLMag5Nf3/IPSJNG8jw==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5-canary.8.tgz",
+      "integrity": "sha512-HkWNlI6rf/DeUenwUF1XC5j09kP5pzcZjGSqo09/qdWERxXz7wdUGIcDyELD++fbCuB6gdwbz9A1A5RvMKi0QA==",
       "cpu": [
         "ia32"
       ],
@@ -3411,9 +3411,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.2.tgz",
-      "integrity": "sha512-O7bort1Vld00cu8g0jHZq3cbSTUNMohOEvYqsqE10+yfohhdPHzvzO+ziJRz4Dyyr/fYKREwS7gR4JC0soSOMw==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5-canary.8.tgz",
+      "integrity": "sha512-CHdF7IqCv/LXKL/DiYOXReQfrgJyx9u/IEqcYk+R/k/F9czK8x9zc6jZaQqWiMKl7EYzlLZMUScoGZ2BTQ2Lbw==",
       "cpu": [
         "x64"
       ],
@@ -12239,8 +12239,7 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "devOptional": true
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
       "version": "13.20.0",
@@ -15353,16 +15352,17 @@
       "devOptional": true
     },
     "node_modules/next": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.2.tgz",
-      "integrity": "sha512-aNFqLs3a3nTGvLWlO9SUhCuMUHVPSFQC0+tDNGAsDXqx+WJDFSbvc233gOJ5H19SBc7nw36A9LwQepOJ2u/8Kg==",
+      "version": "13.4.5-canary.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.5-canary.8.tgz",
+      "integrity": "sha512-S37NTi8SgsqkoiFQvwmT17YdSZVvnr6mfVMbXgSIbUCY6P2Pcjh5pNyurjGGnxrxlRKSKd2Hj0XFaO7VR8A1oA==",
       "dependencies": {
-        "@next/env": "13.4.2",
+        "@next/env": "13.4.5-canary.8",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
         "zod": "3.21.4"
       },
       "bin": {
@@ -15372,20 +15372,19 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.2",
-        "@next/swc-darwin-x64": "13.4.2",
-        "@next/swc-linux-arm64-gnu": "13.4.2",
-        "@next/swc-linux-arm64-musl": "13.4.2",
-        "@next/swc-linux-x64-gnu": "13.4.2",
-        "@next/swc-linux-x64-musl": "13.4.2",
-        "@next/swc-win32-arm64-msvc": "13.4.2",
-        "@next/swc-win32-ia32-msvc": "13.4.2",
-        "@next/swc-win32-x64-msvc": "13.4.2"
+        "@next/swc-darwin-arm64": "13.4.5-canary.8",
+        "@next/swc-darwin-x64": "13.4.5-canary.8",
+        "@next/swc-linux-arm64-gnu": "13.4.5-canary.8",
+        "@next/swc-linux-arm64-musl": "13.4.5-canary.8",
+        "@next/swc-linux-x64-gnu": "13.4.5-canary.8",
+        "@next/swc-linux-x64-musl": "13.4.5-canary.8",
+        "@next/swc-win32-arm64-msvc": "13.4.5-canary.8",
+        "@next/swc-win32-ia32-msvc": "13.4.5-canary.8",
+        "@next/swc-win32-x64-msvc": "13.4.5-canary.8"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
         "fibers": ">= 3.1.0",
-        "node-sass": "^6.0.0 || ^7.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
@@ -15395,9 +15394,6 @@
           "optional": true
         },
         "fibers": {
-          "optional": true
-        },
-        "node-sass": {
           "optional": true
         },
         "sass": {
@@ -19545,7 +19541,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
       "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-      "devOptional": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-config-next": "13.3.0",
     "lucide-react": "^0.162.0",
     "mysql2": "^3.2.3",
-    "next": "^13.4.2",
+    "next": "^13.4.5-canary.8",
     "postcss": "8.4.22",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
Fixes #22  - waiting until official next release to bump package and merge (13.4.3)
https://github.com/vercel/next.js/issues/49450